### PR TITLE
listTransactions method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ppc-rpc
+# peercoin-rpc
 
 Peercoin RPC for TypeScript with Response Type Enforcement
 
@@ -11,7 +11,7 @@ Peercoin RPC for TypeScript with Response Type Enforcement
 ```typescript
 import PeercoinRPC from 'peercoin-rpc';
 
-const rpc = new PeercoinRPC('http://localhost:8332');
+const rpc = new PeercoinRPC('http://localhost:9904');
 
 const balance = await rpc.getBalance();
 console.log(balance);

--- a/src/PeercoinRPC.ts
+++ b/src/PeercoinRPC.ts
@@ -234,6 +234,10 @@ export default class PeercoinRPC {
     );
   }
 
+  public async listTransactions(address: string = "*", count: number) {
+    return this.cmdWithRetry('listtransactions', address, count)
+  }
+
   public async getTransaction(txhash: string) {
     return this.cmdWithRetryAndDecode(decoders.GetTransactionResultDecoder, 'gettransaction', txhash);
   }


### PR DESCRIPTION
This is how `listtransactions` should look like, the node can filter by address and there is a `count` argument. It defaults to 10 and it can go up to `n`.

I guess it needs this `decoders.GetListTransactions...` type enforcement thing but I really don't have experience with it.